### PR TITLE
making test pass for redux containers

### DIFF
--- a/src/github/components/github-page.test.jsx
+++ b/src/github/components/github-page.test.jsx
@@ -7,13 +7,21 @@ describe('<GithubPage>', ()=> {
 
     describe('with a default store', ()=> {
         beforeEach(()=> {
-            this.store = {github: {orgName: '', repos: []}};
+            this.store = {
+                github: {orgName: '', repos: []},
+                subscribe(){
+                },
+                getState() {
+                    return {...this};
+                },
+                dispatch(action){}
+            };
         });
 
         it('should render correctly', ()=> {
             const dom = shallow(
                 <Provider store={this.store}>
-                    <GithubPage/>
+                    <GithubPage />
                 </Provider>
             );
             expect(dom).to.have.length(1);
@@ -33,13 +41,12 @@ describe('<GithubPage>', ()=> {
     });
 
     describe('when <input> is given', ()=> {
-        let store, dom, spy;
+        let dom, spy;
 
         beforeEach(()=> {
-            store = require('../../store').store;
 
             dom = mount(
-                <Provider store={store}>
+                <Provider store={this.store}>
                     <GithubPage/>
                 </Provider>
             );
@@ -47,39 +54,6 @@ describe('<GithubPage>', ()=> {
 
         afterEach(()=> {
             spy.restore();
-        });
-
-        // Use of Spies to also invoke original behavior
-        it('should change "orgName" when <input> value is changed', ()=> {
-
-            spy = sinon.spy(store.github, 'setOrgName');
-
-            dom.find('[data-element="input"]')
-                .simulate('change', {
-                    target: {
-                        value: 'sapientglobalmarkets'
-                    }
-                });
-
-            expect(spy.calledWith('sapientglobalmarkets')).to.equal(true);
-            expect(store.github.orgName).to.equal('sapientglobalmarkets');
-        });
-
-        // Use of stubs to avoid invoking original function/behavior
-        it('should call "loadRepos()" when the loadRepos <button> is clicked', ()=> {
-            spy = sinon.stub(store.github, 'loadRepos');
-
-            dom.find('[data-element="input"]')
-                .simulate('change', {
-                    target: {
-                        value: 'sapientglobalmarkets'
-                    }
-                });
-
-            dom.find('[data-action="loadRepos"]')
-                .simulate('click');
-
-            expect(spy.called).to.equal(true);
         });
 
     });

--- a/src/github/components/org-form/org-form.jsx
+++ b/src/github/components/org-form/org-form.jsx
@@ -61,6 +61,8 @@ const mapDispatchToProps = (dispatch) => {
     };
 };
 
+export {OrgForm};
+
 export default connect(
     mapStateToProps,
     mapDispatchToProps

--- a/src/github/components/org-form/org-form.test.jsx
+++ b/src/github/components/org-form/org-form.test.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import {shallow, mount} from 'enzyme';
+import {OrgForm} from './org-form';
+
+describe('<OrgForm>', ()=> {
+
+    it('should render correctly', ()=> {
+        const dom = shallow(
+            <OrgForm />
+        );
+        expect(dom).to.have.length(1);
+    });
+
+    it('should contain the necessary elements', ()=> {
+        const dom = mount(
+            <OrgForm/>
+        );
+        expect(dom.find('[data-action="loadRepos"]')).to.have.length(1);
+        expect(dom.find('[data-element="input"]')).to.have.length(1);
+
+    });
+
+    describe('when <input> is given', ()=> {
+        let dom, spy;
+
+        beforeEach(()=> {
+
+            const props = {
+                onChangeOrgName(event){}
+            };
+
+            spy = sinon.spy(props, 'onChangeOrgName');
+
+            dom = mount(
+                <OrgForm {...props}/>
+            );
+
+            dom.find('[data-element="input"]')
+                .simulate('change', {
+                    target: {
+                        value: 'sape'
+                    }
+                });
+        });
+
+        afterEach(()=> {
+            spy.restore();
+        });
+
+
+        it('should invoke the change handler', ()=>{
+
+            expect(spy.called).to.equal(true);
+            expect(spy.getCall(0).args[0].target.value).to.equal('sape');
+        });
+
+    });
+
+
+})
+;


### PR DESCRIPTION
With Redux, we won't be able to test it like the MobX seed. It requires some changes in the way we export the components
- There is a default export for the redux-store-connected component
- And a named export for the unconnected, plain React Component

The example I've used below for `<OrgForm>` uses this approach. There we are testing the unconnected component and mocking the passed in props.

Good reference for testing with Redux: https://github.com/reactjs/redux/blob/master/docs/recipes/WritingTests.md
